### PR TITLE
Refector uploadPDF()

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Unofficial reMarkable api wrapper for node.js based on [these unofficial docs](h
 This module is typed for TypeScript, but you can still use JavaScript with it.
 
 ## Installation
+
 ```bash
 yarn add remarkable-typescript
 # OR
@@ -73,7 +74,7 @@ const fs = require('fs');
     * Params: name: string, file: Buffer
     * Returns: id: string
     */
-    const pdfUploadedId = await client.uploadPDF('My PDF name', myPDF);
+    const pdfUploadedId = await client.uploadPDF('name of PDF document', ID: '181a124b-bbdf-4fdd-8310-64fa87bc9c7f', pdfFileBuffer, /*optional UUID of parent folder*/);
 
     /*
     * Download a ZIP file to your reMarkable (with the annotations)
@@ -97,7 +98,7 @@ const fs = require('fs');
     const epubDocId = await client.uploadEPUB('name of ePub document', ID: '181a124b-bbdf-4fdd-8310-64fa87bc9c7f', epubFileBuffer, /*optional UUID of parent folder*/);
 
     /*
-    * Create a directory 
+    * Create a directory
     * Params: name: string, id: string, epubFileBuffer: Buffer, parent?: string
     * Returns: id: string
     */
@@ -107,7 +108,5 @@ const fs = require('fs');
 ```
 
 ## License
+
 MIT
-
-
-

--- a/src/remarkable.ts
+++ b/src/remarkable.ts
@@ -273,21 +273,26 @@ export default class Remarkable {
     return bodyUpdateStatus[0].ID;
   }
 
-  public async uploadPDF(name: string, file: Buffer): Promise<string> {
+  /**
+   *
+   * @param name the display name for the document
+   * @param id uuid string that identifies the document
+   * @param file the file data we would like to upload
+   * @param parentId (optional) if the document should belong to a folder the uuid of the folder must be specified
+   */
+  public async uploadPDF(name: string, id: string, file: Buffer, parentId?: string): Promise<string> {
     if (!this.token) throw Error('You need to call refreshToken() first');
 
-    const ID = uuidv4();
-
     // We create the zip file to get uploaded
-    this.zip.file(`${ID}.content`, JSON.stringify(defaultPDFContent));
-    this.zip.file(`${ID}.pagedata`, []);
-    this.zip.file(`${ID}.pdf`, file);
+    this.zip.file(`${id}.content`, JSON.stringify(defaultPDFContent));
+    this.zip.file(`${id}.pagedata`, []);
+    this.zip.file(`${id}.pdf`, file);
     const zipContent = await this.zip.generateAsync({ type: 'nodebuffer' });
 
-    await this.uploadZip(name, ID, zipContent);
+    await this.uploadZip(name, id, zipContent, parentId);
 
     this.zip = new JSZip();
-    return ID;
+    return id;
   }
 
   /**


### PR DESCRIPTION
`uploadPDF()` and `uploadEPUB()` are essentially the same function, but don't have the same functionality. Added equivalent features to `uploadPDF()`.

- added parentId parameter
- added id parameter
- updated docs